### PR TITLE
[Anti-Cheat]: Line Continuity check

### DIFF
--- a/root/2d/script/line.js
+++ b/root/2d/script/line.js
@@ -2,6 +2,8 @@ window.lines = {};
 
 class Line {
     constructor(x1, y1, x2, y2) {
+        this.x = x1+x2
+        this.y = y1+y2
         this.hidden = false
         this.elem = document.createElementNS("http://www.w3.org/2000/svg", "line");
         window.lines[`${x1+x2},${y1+y2}`] = this;


### PR DESCRIPTION
In any maze generated by A-Maze, there should be only one non-overlapping path between any two given points.

However, it is currently possible to trick the rating system by changing the maze data.

Example of a maze data with this issue: `aahabacadaeafaga-acbc-aaabcbca`

So, Line Continuity Check has been added, to ensure that there is no line present, without being relevant to the maze.